### PR TITLE
Do not allow None value for endpoint

### DIFF
--- a/stripe_block.py
+++ b/stripe_block.py
@@ -49,7 +49,7 @@ class WebServer(PropertyHolder):
 
     host = StringProperty(title='Host', default='0.0.0.0')
     port = IntProperty(title='Port', default=8182)
-    endpoint = StringProperty(title='Endpoint', default="", allow_none=True)
+    endpoint = StringProperty(title='Endpoint', default="")
 
 
 class Stripe(GeneratorBlock):


### PR DESCRIPTION
We investigated this and determined that it is not valid to use `None` for an endpoint. A bug was found in the system designer where empty properties were  being saved as `null` rather than an empty string. An empty configuration for `endpoint` is valid, and until that bug is fixed can be written as `{{ str() }}`